### PR TITLE
Junzhe details popup it2

### DIFF
--- a/backend/routes/places.js
+++ b/backend/routes/places.js
@@ -28,6 +28,12 @@ router.get('/autocomplete', async (req, res) => {
     }
 
     try {
+        if (!process.env.SERP_API_KEY) {
+            return res.status(500).json({
+                error: 'SERP_API_KEY is not configured on the backend',
+            });
+        }
+
         const { lat, lng } = req.query;
         const params = {
             engine: 'google_maps_autocomplete',
@@ -39,6 +45,12 @@ router.get('/autocomplete', async (req, res) => {
         }
 
         const results = await serpApiGet(params);
+
+        if (results?.error) {
+            return res.status(502).json({
+                error: `SerpAPI error: ${results.error}`,
+            });
+        }
 
         const suggestions = (results.suggestions || [])
             .filter((s) => s.type === 'place')

--- a/frontend/src/components/LocationAutocomplete.jsx
+++ b/frontend/src/components/LocationAutocomplete.jsx
@@ -7,6 +7,7 @@ function LocationAutocomplete({ id, value, onChange, onSelect, placeholder, requ
     const [query, setQuery] = useState(value || '');
     const [suggestions, setSuggestions] = useState([]);
     const [isOpen, setIsOpen] = useState(false);
+    const [isFocused, setIsFocused] = useState(false);
     const containerRef = useRef(null);
 
     // Sync query when parent resets value to empty (e.g. form clear)
@@ -30,16 +31,23 @@ function LocationAutocomplete({ id, value, onChange, onSelect, placeholder, requ
                     params.set('lng', coords.lng);
                 }
                 const res = await fetch(`/api/places/autocomplete?${params}`);
+                if (!res.ok) {
+                    setSuggestions([]);
+                    setIsOpen(false);
+                    return;
+                }
                 const data = await res.json();
-                setSuggestions(data.suggestions || []);
-                setIsOpen(true);
+                const nextSuggestions = data.suggestions || [];
+                setSuggestions(nextSuggestions);
+                setIsOpen(isFocused && nextSuggestions.length > 0);
             } catch {
                 setSuggestions([]);
+                setIsOpen(false);
             }
         }, 300);
 
         return () => clearTimeout(timer);
-    }, [query]);
+    }, [query, isFocused, coords]);
 
     // Close dropdown on outside click
     useEffect(() => {
@@ -61,12 +69,25 @@ function LocationAutocomplete({ id, value, onChange, onSelect, placeholder, requ
         onSelect?.({ label: full, latitude: suggestion.latitude, longitude: suggestion.longitude });
         setSuggestions([]);
         setIsOpen(false);
+        setIsFocused(false);
     }
 
     function handleChange(e) {
         const val = e.target.value;
         setQuery(val);
         onChange(val);
+    }
+
+    function handleFocus() {
+        setIsFocused(true);
+        if (suggestions.length > 0 && query.trim().length >= 2) {
+            setIsOpen(true);
+        }
+    }
+
+    function handleBlur() {
+        setIsFocused(false);
+        setIsOpen(false);
     }
 
     return (
@@ -78,10 +99,12 @@ function LocationAutocomplete({ id, value, onChange, onSelect, placeholder, requ
                 placeholder={placeholder}
                 value={query}
                 onChange={handleChange}
+                onFocus={handleFocus}
+                onBlur={handleBlur}
                 required={required}
                 autoComplete='off'
             />
-            {isOpen && suggestions.length > 0 && (
+            {isFocused && isOpen && suggestions.length > 0 && (
                 <ul className='absolute z-50 mt-1 w-full rounded-md border border-input bg-background shadow-md'>
                     {suggestions.map((s, i) => (
                         <li

--- a/frontend/src/components/PostCard.jsx
+++ b/frontend/src/components/PostCard.jsx
@@ -15,6 +15,33 @@ import SubmitBox from './SubmitBox';
 const PostCard = ({ post, onDelete, onUpdate, coords }) => {
     const { _id, title, description, user, trip, type = 'request' } = post;
     const isOffer = type === 'offer';
+    const startLocationLabel =
+        typeof trip?.startLocation === 'string'
+            ? trip.startLocation
+            : trip?.startLocation?.title || '';
+    const endLocationLabel =
+        typeof trip?.endLocation === 'string'
+            ? trip.endLocation
+            : trip?.endLocation?.title || '';
+    const startLat = Number(trip?.startLocation?.gps_coordinates?.latitude);
+    const startLng = Number(trip?.startLocation?.gps_coordinates?.longitude);
+    const endLat = Number(trip?.endLocation?.gps_coordinates?.latitude);
+    const endLng = Number(trip?.endLocation?.gps_coordinates?.longitude);
+    const hasStartCoords = Number.isFinite(startLat) && Number.isFinite(startLng);
+    const hasEndCoords = Number.isFinite(endLat) && Number.isFinite(endLng);
+    const hasRouteCoords = hasStartCoords && hasEndCoords;
+
+    const mapEmbedUrl = hasRouteCoords
+        ? `https://maps.google.com/maps?output=embed&saddr=${startLat},${startLng}&daddr=${endLat},${endLng}`
+        : hasStartCoords
+          ? `https://maps.google.com/maps?q=${startLat},${startLng}&z=14&output=embed`
+          : hasEndCoords
+            ? `https://maps.google.com/maps?q=${endLat},${endLng}&z=14&output=embed`
+            : '';
+
+    const mapsRouteUrl = hasRouteCoords
+        ? `https://www.google.com/maps/dir/?api=1&origin=${startLat},${startLng}&destination=${endLat},${endLng}`
+        : '';
 
     const [editOpen, setEditOpen] = useState(false);
     const [deleteOpen, setDeleteOpen] = useState(false);
@@ -91,19 +118,19 @@ const PostCard = ({ post, onDelete, onUpdate, coords }) => {
                         Trip Details
                     </h4>
                     <div className='space-y-2'>
-                        {trip.startLocation?.title && (
+                        {startLocationLabel && (
                             <div className='flex items-center gap-2 text-sm'>
                                 <MapPin className='w-4 h-4 text-green-600' />
                                 <span className='text-gray-600'>
-                                    From: {trip.startLocation.title}
+                                    From: {startLocationLabel}
                                 </span>
                             </div>
                         )}
-                        {trip.endLocation?.title && (
+                        {endLocationLabel && (
                             <div className='flex items-center gap-2 text-sm'>
                                 <MapPin className='w-4 h-4 text-red-600' />
                                 <span className='text-gray-600'>
-                                    To: {trip.endLocation.title}
+                                    To: {endLocationLabel}
                                 </span>
                             </div>
                         )}
@@ -158,9 +185,109 @@ const PostCard = ({ post, onDelete, onUpdate, coords }) => {
                     </DialogContent>
                 </Dialog>
 
-                <Button variant='outline' size='sm'>
-                    Details
-                </Button>
+                <Dialog>
+                    <DialogTrigger asChild>
+                        <Button variant='outline' size='sm'>
+                            Details
+                        </Button>
+                    </DialogTrigger>
+
+                    <DialogContent className='sm:max-w-[560px]'>
+                        <DialogHeader>
+                            <DialogTitle>Ride Details</DialogTitle>
+                            <DialogDescription>
+                                Full trip and contact info for this post.
+                            </DialogDescription>
+                        </DialogHeader>
+
+                        <div className='space-y-4 text-sm'>
+                            <div>
+                                <p className='font-medium text-gray-900'>Title</p>
+                                <p className='text-gray-600'>{title}</p>
+                            </div>
+
+                            {description && (
+                                <div>
+                                    <p className='font-medium text-gray-900'>Description</p>
+                                    <p className='text-gray-600'>{description}</p>
+                                </div>
+                            )}
+
+                            <div className='grid gap-3 sm:grid-cols-2'>
+                                <div>
+                                    <p className='font-medium text-gray-900'>Rider</p>
+                                    <p className='text-gray-600'>{user?.name || 'N/A'}</p>
+                                </div>
+                                <div>
+                                    <p className='font-medium text-gray-900'>Email</p>
+                                    <p className='text-gray-600'>{user?.email || 'N/A'}</p>
+                                </div>
+                            </div>
+
+                            <div className='grid gap-3 sm:grid-cols-2'>
+                                <div>
+                                    <p className='font-medium text-gray-900'>From</p>
+                                    <p className='text-gray-600'>
+                                        {startLocationLabel || 'N/A'}
+                                    </p>
+                                </div>
+                                <div>
+                                    <p className='font-medium text-gray-900'>To</p>
+                                    <p className='text-gray-600'>
+                                        {endLocationLabel || 'N/A'}
+                                    </p>
+                                </div>
+                            </div>
+
+                            <div className='grid gap-3 sm:grid-cols-2'>
+                                <div>
+                                    <p className='font-medium text-gray-900'>Date</p>
+                                    <p className='text-gray-600'>{trip?.date || 'N/A'}</p>
+                                </div>
+                                <div>
+                                    <p className='font-medium text-gray-900'>Time</p>
+                                    <p className='text-gray-600'>{trip?.time || 'N/A'}</p>
+                                </div>
+                            </div>
+
+                            <div>
+                                <p className='font-medium text-gray-900'>Post ID</p>
+                                <p className='text-gray-600'>#{_id?.slice(-6) || 'N/A'}</p>
+                            </div>
+
+                            <div>
+                                <p className='font-medium text-gray-900 mb-2'>Map</p>
+                                {mapEmbedUrl ? (
+                                    <div className='space-y-2'>
+                                        <div className='h-56 w-full overflow-hidden rounded-md border border-gray-200'>
+                                            <iframe
+                                                title={`Trip map for post ${_id || 'unknown'}`}
+                                                src={mapEmbedUrl}
+                                                loading='lazy'
+                                                className='h-full w-full'
+                                                referrerPolicy='no-referrer-when-downgrade'
+                                            />
+                                        </div>
+                                        {mapsRouteUrl && (
+                                            <a
+                                                href={mapsRouteUrl}
+                                                target='_blank'
+                                                rel='noreferrer'
+                                                className='text-sm text-blue-600 hover:underline'
+                                            >
+                                                Open route in Google Maps
+                                            </a>
+                                        )}
+                                    </div>
+                                ) : (
+                                    <p className='text-gray-600'>
+                                        Map preview is unavailable because coordinates were not saved for this post.
+                                    </p>
+                                )}
+                            </div>
+                        </div>
+                    </DialogContent>
+                </Dialog>
 
                 {/* Delete Confirmation Dialog */}
                 <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>


### PR DESCRIPTION
## PR Title
feat: add Details popup map + fix location autocomplete focus behavior

## Summary
This PR implements the Details popup flow on each PostCard and improves location autocomplete behavior in the ride form.

## What Changed
- Added a `Details` popup on each `PostCard`.
- Added map preview in the `Details` popup using saved start/end coordinates.
- Added fallback behavior when coordinates are missing on older posts.
- Fixed autocomplete dropdown behavior so suggestions only appear for the currently focused input.
- Improved autocomplete request handling for non-OK backend responses.
- Added backend validation/error responses for missing `SERP_API_KEY` and SerpAPI upstream errors.

## Why
- Issue #38 requests a popup for the `Details` button on PostCard.
- The map view is shown inside the Details popup to make trip context clearer.
- Users reported incorrect autocomplete behavior where start suggestions appeared while typing in end location.

## Files Changed
- `frontend/src/components/PostCard.jsx`
- `frontend/src/components/LocationAutocomplete.jsx`
- `backend/routes/places.js`

## Testing
- `cd frontend && pnpm build`
- Manual verification:
  - `Details` button opens modal with trip metadata.
  - Map preview renders when coordinates exist.
  - Fallback text appears when coordinates are missing.
  - Start/End autocomplete dropdown appears only on the focused input.
  - Backend autocomplete endpoint returns explicit errors when misconfigured.

## Notes
- Autocomplete depends on `SERP_API_KEY` in `backend/.env`.
- Older posts without saved coordinates will not show embedded map, by design.

## Issue Addressed
- Addresses #38