### PR TITLE
Archive feature added to profile

### DIFF
--- a/backend/routes/posts.js
+++ b/backend/routes/posts.js
@@ -87,7 +87,7 @@ router.get('/', async (req, res) => {
   res.json(enrichedPosts);
 });
 
-// READ ARCHIVED POSTS (for future profile feature)
+// READ ARCHIVED POSTS
 router.get('/archived', async (req, res) => {
   const posts = await getDB().collection('posts').find({ archived: true }).toArray();
   

--- a/frontend/src/components/BottomNav.jsx
+++ b/frontend/src/components/BottomNav.jsx
@@ -11,7 +11,7 @@ const BottomNav = () => {
 
   return (
     <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 z-50">
-      <div className="flex justify-around items-center h-16 max-w-lg mx-auto">
+      <div className="flex justify-around items-center h-16">
         {navItems.map(({ to, icon: Icon, label }) => (
           <NavLink
             key={to}

--- a/frontend/src/components/PostCard.jsx
+++ b/frontend/src/components/PostCard.jsx
@@ -4,16 +4,7 @@ import WeatherDisplay from './WeatherDisplay';
 import WeatherForecastDialog from './WeatherForecastDialog';
 import React, { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-
-function formatTime(time) {
-    if (!time) return time;
-    const [hourStr, minute] = time.split(':');
-    const hour = parseInt(hourStr, 10);
-    if (isNaN(hour)) return time;
-    const period = hour >= 12 ? 'PM' : 'AM';
-    const hour12 = hour % 12 || 12;
-    return `${hour12}:${minute} ${period}`;
-}
+import { cn, formatTime, formatDate } from '@/lib/utils';
 import { MapPin, Calendar, Clock, MessageCircle, Pencil, Trash2, Info, User, Mail, Phone, Navigation, ExternalLink, UserPlus, Car, Users, CheckCircle, UserMinus, Hash } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
@@ -359,7 +350,7 @@ const PostCard = ({ post, onDelete, onUpdate, coords, showActions = false, route
                                 <div className='flex items-center gap-1 text-sm'>
                                     <Calendar className='w-4 h-4 text-gray-500' />
                                     <span className='text-gray-600'>
-                                        {trip.date}
+                                        {formatDate(trip.date)}
                                     </span>
                                 </div>
                             )}
@@ -1047,7 +1038,7 @@ const PostCard = ({ post, onDelete, onUpdate, coords, showActions = false, route
                                             {trip.date && (
                                                 <div className='flex items-center gap-2 text-gray-700'>
                                                     <Calendar className='w-4 h-4 text-gray-400 shrink-0' />
-                                                    <span>{trip.date}</span>
+                                                    <span>{formatDate(trip.date)}</span>
                                                 </div>
                                             )}
                                             {trip.time && (

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -95,3 +95,21 @@ export function filterPostsByRouteRadius(posts, route, radiusKm) {
         .sort((left, right) => left.routeDistanceKm - right.routeDistanceKm)
         .map(({ post }) => post);
 }
+
+// Returns 12 hr time instead of 24 hr
+export function formatTime(time) {
+    if (!time) return time;
+    const [hourStr, minute] = time.split(':');
+    const hour = parseInt(hourStr, 10);
+    if (isNaN(hour)) return time;
+    const period = hour >= 12 ? 'PM' : 'AM';
+    const hour12 = hour % 12 || 12;
+    return `${hour12}:${minute} ${period}`;
+}
+
+// Returns format in MM-DD-YYYY
+export function formatDate(date) {
+    if (!date) return date;
+    const [year, month, day] = date.split('-');
+    return `${month}-${day}-${year}`;
+}

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { User, Mail, Phone, BookOpen, Calendar, MapPin, Edit3, Save, X, Camera, Upload, ArrowLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { formatTime, formatDate } from '@/lib/utils';
 
 const API_ROOT = (import.meta.env.VITE_API_BASE_URL || '/api').replace(/\/$/, '');
 
@@ -533,13 +534,15 @@ function ProfilePage({ currentUser, onUserUpdate }) {
                         }`}>
                           {post.type === 'offer' ? 'Offered Ride' : 'Requested Ride'}
                         </span>
-                        <span className="text-xs text-gray-400">{post.trip?.date}</span>
+                        <span className="text-xs text-gray-400">{formatDate(post.trip?.date)}</span>
                       </div>
                       <p className="text-sm font-medium text-gray-800">
                         {post.title || 'Unknown route'}
                       </p>
                       {post.trip?.time && (
-                        <p className="text-xs text-gray-500 mt-0.5">{post.trip.time}</p>
+                        <p className="text-xs text-gray-500 mt-0.5">
+                          {formatTime(post.trip?.time)}
+                        </p>
                       )}
                       {post.description && (
                         <>

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -67,6 +67,8 @@ function ProfilePage({ currentUser, onUserUpdate }) {
 
   // Avatar preview state
   const [avatarPreview, setAvatarPreview] = useState(null);
+  const [archivedPosts, setArchivedPosts] = useState([]);
+  const [archivedLoading, setArchivedLoading] = useState(true);
 
   // Reset form when currentUser changes or edit mode is cancelled
   useEffect(() => {
@@ -81,6 +83,22 @@ function ProfilePage({ currentUser, onUserUpdate }) {
     setAvatarPreview(null);
     setPhoneWarning('');
   }, [currentUser, isEditing]);
+
+  useEffect(() => {
+    const fetchArchived = async () => {
+      try {
+        const res = await fetch(`${API_ROOT}/posts/archived`);
+        const data = await res.json();
+        const mine = data.filter(p => p.user?.email === currentUser?.email);
+        setArchivedPosts(mine);
+      } catch (err) {
+        console.error('Failed to load archived posts', err);
+      } finally {
+        setArchivedLoading(false);
+      }
+    };
+    fetchArchived();
+  }, [currentUser?.email]);
 
   const handleInputChange = (field, value) => {
     setFormData(prev => ({ ...prev, [field]: value }));
@@ -490,6 +508,39 @@ function ProfilePage({ currentUser, onUserUpdate }) {
                 )}
               </div>
             </div>
+          </div>
+        </div>
+        {/* Past Trips */}
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 mt-6">
+          <div className="px-6 py-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">Past Trips</h2>
+            {archivedLoading ? (
+              <p className="text-gray-500 text-sm">Loading...</p>
+            ) : archivedPosts.length === 0 ? (
+              <p className="text-gray-500 text-sm">No past trips yet.</p>
+            ) : (
+              <div className="space-y-3">
+                {archivedPosts.map(post => (
+                  <div key={post._id} className="border border-gray-100 rounded-lg p-4 bg-gray-50">
+                    <div className="flex items-center justify-between mb-1">
+                      <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${post.type === 'offer'
+                          ? 'bg-green-100 text-green-700'
+                          : 'bg-blue-100 text-blue-700'
+                        }`}>
+                        {post.type === 'offer' ? 'Offered Ride' : 'Requested Ride'}
+                      </span>
+                      <span className="text-xs text-gray-400">{post.trip?.date}</span>
+                    </div>
+                    <p className="text-sm font-medium text-gray-800">
+                      {post.title || 'Unknown route'}
+                    </p>
+                    {post.trip?.time && (
+                      <p className="text-xs text-gray-500 mt-0.5">{post.trip.time}</p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -54,6 +54,7 @@ function ProfilePage({ currentUser, onUserUpdate }) {
   const [success, setSuccess] = useState('');
   const [phoneWarning, setPhoneWarning] = useState('');
   const fileInputRef = useRef(null);
+  const [visibleCount, setVisibleCount] = useState(3);
   
   // Form state
   const [formData, setFormData] = useState({
@@ -519,27 +520,37 @@ function ProfilePage({ currentUser, onUserUpdate }) {
             ) : archivedPosts.length === 0 ? (
               <p className="text-gray-500 text-sm">No past trips yet.</p>
             ) : (
-              <div className="space-y-3">
-                {archivedPosts.map(post => (
-                  <div key={post._id} className="border border-gray-100 rounded-lg p-4 bg-gray-50">
-                    <div className="flex items-center justify-between mb-1">
-                      <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${post.type === 'offer'
-                          ? 'bg-green-100 text-green-700'
-                          : 'bg-blue-100 text-blue-700'
-                        }`}>
-                        {post.type === 'offer' ? 'Offered Ride' : 'Requested Ride'}
-                      </span>
-                      <span className="text-xs text-gray-400">{post.trip?.date}</span>
+              <>
+                <div className="space-y-3">
+                  {archivedPosts.slice(0, visibleCount).map(post => (
+                    <div key={post._id} className="border border-gray-100 rounded-lg p-4 bg-gray-50">
+                      <div className="flex items-center justify-between mb-1">
+                        <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${post.type === 'offer'
+                            ? 'bg-green-100 text-green-700'
+                            : 'bg-blue-100 text-blue-700'
+                          }`}>
+                          {post.type === 'offer' ? 'Offered Ride' : 'Requested Ride'}
+                        </span>
+                        <span className="text-xs text-gray-400">{post.trip?.date}</span>
+                      </div>
+                      <p className="text-sm font-medium text-gray-800">
+                        {post.title || 'Unknown route'}
+                      </p>
+                      {post.trip?.time && (
+                        <p className="text-xs text-gray-500 mt-0.5">{post.trip.time}</p>
+                      )}
                     </div>
-                    <p className="text-sm font-medium text-gray-800">
-                      {post.title || 'Unknown route'}
-                    </p>
-                    {post.trip?.time && (
-                      <p className="text-xs text-gray-500 mt-0.5">{post.trip.time}</p>
-                    )}
-                  </div>
-                ))}
-              </div>
+                  ))}
+                </div>
+                {visibleCount < archivedPosts.length && (
+                  <button
+                    onClick={() => setVisibleCount(archivedPosts.length)}
+                    className="mt-4 text-sm text-blue-600 hover:text-blue-800 font-medium"
+                  >
+                    See all ({archivedPosts.length} trips)
+                  </button>
+                )}
+              </>
             )}
           </div>
         </div>

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -55,7 +55,8 @@ function ProfilePage({ currentUser, onUserUpdate }) {
   const [phoneWarning, setPhoneWarning] = useState('');
   const fileInputRef = useRef(null);
   const [visibleCount, setVisibleCount] = useState(3);
-  
+  const [expandedPostId, setExpandedPostId] = useState(null);
+
   // Form state
   const [formData, setFormData] = useState({
     name: currentUser?.name || '',
@@ -107,7 +108,7 @@ function ProfilePage({ currentUser, onUserUpdate }) {
 
   const handleNameChange = (value) => {
     setFormData(prev => ({ ...prev, name: value }));
-    
+
     const trimmed = value.trim();
     if (!trimmed) {
       setError('Name cannot be empty.');
@@ -209,7 +210,7 @@ function ProfilePage({ currentUser, onUserUpdate }) {
       return;
     }
     const formattedPhone = trimmedPhone ? formatUSPhoneNumber(trimmedPhone) : '';
-    
+
     setIsLoading(true);
     setError('');
     setSuccess('');
@@ -235,13 +236,13 @@ function ProfilePage({ currentUser, onUserUpdate }) {
       }
 
       const { user } = payload;
-      
+
       // Update the user in app state and localStorage
       onUserUpdate(user);
-      
+
       setIsEditing(false);
       setSuccess('Profile updated successfully!');
-      
+
       // Clear success message after 3 seconds
       setTimeout(() => setSuccess(''), 3000);
     } catch (err) {
@@ -306,7 +307,7 @@ function ProfilePage({ currentUser, onUserUpdate }) {
                     </button>
                   )}
                 </div>
-                
+
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-3 mb-2">
                     <h1 className="text-2xl font-bold text-gray-900">
@@ -342,7 +343,7 @@ function ProfilePage({ currentUser, onUserUpdate }) {
                   )}
                 </div>
               </div>
-              
+
               <div className="flex gap-2 sm:flex-col sm:items-end">
                 {isEditing && (
                   <div className="flex gap-2">
@@ -374,7 +375,7 @@ function ProfilePage({ currentUser, onUserUpdate }) {
                 <p className="text-red-700 text-sm">{error}</p>
               </div>
             )}
-            
+
             {success && (
               <div className="mb-6 p-4 bg-green-50 border border-green-200 rounded-md">
                 <p className="text-green-700 text-sm">{success}</p>
@@ -525,10 +526,11 @@ function ProfilePage({ currentUser, onUserUpdate }) {
                   {archivedPosts.slice(0, visibleCount).map(post => (
                     <div key={post._id} className="border border-gray-100 rounded-lg p-4 bg-gray-50">
                       <div className="flex items-center justify-between mb-1">
-                        <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${post.type === 'offer'
+                        <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+                          post.type === 'offer'
                             ? 'bg-green-100 text-green-700'
                             : 'bg-blue-100 text-blue-700'
-                          }`}>
+                        }`}>
                           {post.type === 'offer' ? 'Offered Ride' : 'Requested Ride'}
                         </span>
                         <span className="text-xs text-gray-400">{post.trip?.date}</span>
@@ -538,6 +540,23 @@ function ProfilePage({ currentUser, onUserUpdate }) {
                       </p>
                       {post.trip?.time && (
                         <p className="text-xs text-gray-500 mt-0.5">{post.trip.time}</p>
+                      )}
+                      {post.description && (
+                        <>
+                          {expandedPostId === post._id && (
+                            <p className="text-sm text-gray-600 mt-2 border-t border-gray-200 pt-2">
+                              {post.description}
+                            </p>
+                          )}
+                          <button
+                            onClick={() => setExpandedPostId(
+                              expandedPostId === post._id ? null : post._id
+                            )}
+                            className="mt-2 text-xs text-blue-600 hover:text-blue-800 font-medium"
+                          >
+                            {expandedPostId === post._id ? 'Show less' : 'View details'}
+                          </button>
+                        </>
                       )}
                     </div>
                   ))}


### PR DESCRIPTION
## Profile Page Archive & Date/Time Formatting Cleanup

### New Features
- **Past Trips Section**: Added "Past Trips" section to profile page displaying archived posts
  - Initially displays 3 trips with "See all" button to expand
  - Each trip shows type badge (Offered/Requested), date, time, and title
  - Descriptions are collapsible with "View details" / "Show less" toggle
  - Tabs on bottom nav are now evenly distributed across screen

### Improvements
  - Created utility functions `formatDate()` and moved existing `formatTime()` in `src/lib/utils.js` to centralize date/time format across app
  - Date format: `MM-DD-YYYY` (e.g., 04-23-2026) instead of day then month
  - Applied formatting to `PostCard` and `ProfilePage` components
  - Note: `SubmitBox` continues using date-fns for date picker UI

### Technical Details
- Fetches archived posts from `/api/posts/archived` endpoint
- Removed duplicate date-fns usage in ProfilePage in favor of shared utils