### PR TITLE
Issue #129: join status + left-list notifications + accepted rides in My Rides

### DIFF
--- a/backend/routes/posts.js
+++ b/backend/routes/posts.js
@@ -8,6 +8,10 @@ function toObjectId(id) {
   return new ObjectId(id);
 }
 
+function escapeRegex(value = '') {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 // Generates a 6-digits code.
 function generateConfirmationCode() {
   const chars = '0123456789';
@@ -336,12 +340,17 @@ router.post('/:id/remove-member', async (req, res) => {
     const postId = toObjectId(req.params.id);
     if (!postId) return res.status(400).json({ error: 'Invalid post id' });
 
-    const { email } = req.body;
+    const { email, name, actorEmail, actorName, actorId } = req.body;
     if (!email) return res.status(400).json({ error: 'Email required' });
 
     const db = getDB();
     const post = await db.collection('posts').findOne({ _id: postId });
     if (!post) return res.status(404).json({ error: 'Post not found' });
+
+    const riderListBefore = post.riderList || [];
+    const removedMember = riderListBefore.find((member) => member.email === email)
+      || riderListBefore.find((member) => name && member.name === name)
+      || null;
 
     await db.collection('posts').updateOne(
       { _id: postId },
@@ -349,7 +358,6 @@ router.post('/:id/remove-member', async (req, res) => {
     );
     // Also remove any entry that matched on name if email was blank
     if (!email) {
-      const { name } = req.body;
       if (name) {
         await db.collection('posts').updateOne(
           { _id: postId },
@@ -358,7 +366,80 @@ router.post('/:id/remove-member', async (req, res) => {
       }
     }
 
-    res.json({ success: true });
+    const updatedPost = await db.collection('posts').findOne({ _id: postId });
+    const remainingRiders = (updatedPost?.riderList || []).filter((member) => member.email !== email);
+    let notifiedCount = 0;
+
+    const removedDisplayName = removedMember?.name || name || email;
+    const actorDisplayName = actorName || removedDisplayName;
+    const removedOwnself = actorEmail && actorEmail === email;
+    const routeSummary = `${post.trip?.startLocation?.title || 'start'} to ${post.trip?.endLocation?.title || 'destination'}`;
+    const dateSummary = post.trip?.date ? ` on ${post.trip.date}` : '';
+    const timeSummary = post.trip?.time ? ` at ${post.trip.time}` : '';
+    const rideSummary = `${routeSummary}${dateSummary}${timeSummary}`;
+    const notificationMessage = removedOwnself
+      ? `${removedDisplayName} left your riding list for ${rideSummary}.`
+      : `${removedDisplayName} was removed from your riding list for ${rideSummary} by ${actorDisplayName}.`;
+
+    // Notify all remaining riders and the post owner.
+    const recipientEmailSet = new Set(
+      remainingRiders
+        .map((member) => (typeof member.email === 'string' ? member.email.trim() : ''))
+        .filter(Boolean)
+    );
+    if (typeof post.user?.email === 'string' && post.user.email.trim()) {
+      recipientEmailSet.add(post.user.email.trim());
+    }
+    if (typeof email === 'string' && email.trim()) {
+      // Don't notify the member who just left/was removed.
+      recipientEmailSet.delete(email.trim());
+    }
+
+    const recipientEmails = Array.from(recipientEmailSet);
+
+    const recipients = [];
+    for (const recipientEmail of recipientEmails) {
+      // Use exact match first, then a case-insensitive fallback for inconsistent email casing.
+      let user = await db.collection('users').findOne(
+        { email: recipientEmail },
+        { projection: { _id: 1, email: 1 } }
+      );
+
+      if (!user) {
+        user = await db.collection('users').findOne(
+          { email: { $regex: `^${escapeRegex(recipientEmail)}$`, $options: 'i' } },
+          { projection: { _id: 1, email: 1 } }
+        );
+      }
+
+      if (user) {
+        recipients.push(user);
+      }
+    }
+
+    if (recipients.length > 0) {
+      const senderObjectId = actorId && ObjectId.isValid(actorId)
+        ? new ObjectId(actorId)
+        : null;
+
+      const result = await db.collection('notifications').insertMany(
+        recipients.map((user) => ({
+          recipientId: user._id,
+          senderName: actorDisplayName || 'HopShare',
+          senderId: senderObjectId,
+          message: notificationMessage,
+          postId,
+          replyToMessage: null,
+          type: 'left_list',
+          response: null,
+          read: false,
+          createdAt: new Date(),
+        }))
+      );
+      notifiedCount = result.insertedCount || 0;
+    }
+
+    res.json({ success: true, notifiedCount });
   } catch (err) {
     console.error('Remove member error:', err);
     res.status(500).json({ error: 'Failed to remove member' });

--- a/frontend/src/components/NotificationMenu.jsx
+++ b/frontend/src/components/NotificationMenu.jsx
@@ -9,7 +9,7 @@ import {
 } from "@/components/ui/sheet";
 import { Bell } from "lucide-react";
 
-const API_ROOT = (import.meta.env.VITE_API_BASE_URL || "").replace(/\/$/, "");
+const API_ROOT = (import.meta.env.VITE_API_BASE_URL || "/api").replace(/\/$/, "");
 
 function NotificationMenu({ currentUser }) {
   const [notifications, setNotifications] = useState([]);
@@ -138,13 +138,22 @@ function NotificationMenu({ currentUser }) {
             </p>
           ) : (
             notifications.map((notif) => {
+              const isLeftListMessage =
+                typeof notif.message === 'string' &&
+                /(left|removed)\b/i.test(notif.message) &&
+                /rid(?:er|ing) list/i.test(notif.message);
+              const displayType = (notif.type === 'left_list' || isLeftListMessage)
+                ? 'left_list'
+                : notif.type;
+
               const typeStyles = {
                 join_list:            { bg: 'bg-purple-50 border-purple-200', badge: 'bg-purple-100 text-purple-700', label: 'Joined List' },
                 ride_request:         { bg: 'bg-blue-50 border-blue-200',     badge: 'bg-blue-100 text-blue-700',     label: 'Ride Request' },
+                left_list:            { bg: 'bg-red-50 border-red-200',       badge: 'bg-red-100 text-red-700',       label: 'Left List' },
 ride_request_response:{ bg: 'bg-gray-50 border-gray-200',     badge: notif.message?.includes('accepted') ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700', label: notif.message?.includes('accepted') ? 'Accepted' : 'Declined' },
                 message:              { bg: 'bg-gray-50 border-gray-200',     badge: 'bg-gray-100 text-gray-600',     label: 'Message' },
               };
-              const style = typeStyles[notif.type] || typeStyles.message;
+              const style = typeStyles[displayType] || typeStyles.message;
               const actionableTypes = ['ride_request', 'join_list'];
               const isActionable = actionableTypes.includes(notif.type) && !notif.response;
               const hasResponded = actionableTypes.includes(notif.type) && notif.response;

--- a/frontend/src/components/PostCard.jsx
+++ b/frontend/src/components/PostCard.jsx
@@ -20,7 +20,7 @@ import {
 } from '@/components/ui/dialog';
 import SubmitBox from './SubmitBox';
 
-const API_ROOT = (import.meta.env.VITE_API_BASE_URL || '').replace(/\/$/, '');
+const API_ROOT = (import.meta.env.VITE_API_BASE_URL || '/api').replace(/\/$/, '');
 const NOTIFICATIONS_ENDPOINT = `${API_ROOT}/notifications`;
 
 const PostCard = ({ post, onDelete, onUpdate, coords, showActions = false, routeSearch, distanceFilter, currentUser }) => {
@@ -438,6 +438,18 @@ const PostCard = ({ post, onDelete, onUpdate, coords, showActions = false, route
                 );
             })()}
 
+            {/* Sharing status */}
+            <div className='flex items-center gap-2 mb-4 text-sm'>
+                <Users className='w-4 h-4 text-gray-400 shrink-0' />
+                {listMembers.length === 0 ? (
+                    <span className='text-gray-400 italic'>No sharing people yet</span>
+                ) : listMembers.length > 1 ? (
+                    <span className='text-gray-700'>{listMembers.length} riders sharing this trip</span>
+                ) : (
+                    <span className='text-gray-700'>1 rider sharing this trip</span>
+                )}
+            </div>
+
             {/* Action buttons */}
             <div className='flex flex-wrap gap-2'>
                 {/* Contact Dialog */}
@@ -569,7 +581,13 @@ const PostCard = ({ post, onDelete, onUpdate, coords, showActions = false, route
                                     const res = await fetch(`${API_ROOT}/posts/${post._id}/remove-member`, {
                                         method: 'POST',
                                         headers: { 'Content-Type': 'application/json' },
-                                        body: JSON.stringify({ email: currentUser.email, name: currentUser.name }),
+                                        body: JSON.stringify({
+                                            email: currentUser.email,
+                                            name: currentUser.name,
+                                            actorEmail: currentUser.email,
+                                            actorName: currentUser.name,
+                                            actorId: currentUser._id,
+                                        }),
                                     });
                                     if (res.ok) {
                                         setListMembers(prev => prev.filter(m => m.email !== currentUser.email));
@@ -818,10 +836,12 @@ const PostCard = ({ post, onDelete, onUpdate, coords, showActions = false, route
                             <div className='bg-gray-50 rounded-lg p-3 space-y-2'>
                                 <p className='text-xs font-semibold uppercase tracking-wide text-gray-400'>
                                     Rider List
-                                    <span className='ml-2 text-gray-500 font-normal normal-case'>({listMembers.length} {listMembers.length === 1 ? 'person' : 'people'})</span>
+                                    {listMembers.length > 1 && (
+                                        <span className='ml-2 text-gray-500 font-normal normal-case'>({listMembers.length} people sharing)</span>
+                                    )}
                                 </p>
                                 {listMembers.length === 0 ? (
-                                    <p className='text-xs text-gray-400 italic'>No one has joined yet.</p>
+                                    <p className='text-xs text-gray-400 italic'>No sharing people yet.</p>
                                 ) : (
                                     <div className='space-y-2'>
                                         {listMembers.map((member, idx) => (
@@ -857,7 +877,13 @@ const PostCard = ({ post, onDelete, onUpdate, coords, showActions = false, route
                                                             const res = await fetch(`${API_ROOT}/posts/${post._id}/remove-member`, {
                                                                 method: 'POST',
                                                                 headers: { 'Content-Type': 'application/json' },
-                                                                body: JSON.stringify({ email: member.email, name: member.name }),
+                                                                body: JSON.stringify({
+                                                                    email: member.email,
+                                                                    name: member.name,
+                                                                    actorEmail: currentUser?.email,
+                                                                    actorName: currentUser?.name,
+                                                                    actorId: currentUser?._id,
+                                                                }),
                                                             });
                                                             if (!res.ok) return;
                                                             setListMembers(prev => prev.filter(m => m.email !== member.email));

--- a/frontend/src/components/PostCard.jsx
+++ b/frontend/src/components/PostCard.jsx
@@ -2,7 +2,7 @@ import { calculateDistance } from './RouteMap';
 import RouteMap from './RouteMap';
 import WeatherDisplay from './WeatherDisplay';
 import WeatherForecastDialog from './WeatherForecastDialog';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { cn, formatTime, formatDate } from '@/lib/utils';
 import { MapPin, Calendar, Clock, MessageCircle, Pencil, Trash2, Info, User, Mail, Phone, Navigation, ExternalLink, UserPlus, Car, Users, CheckCircle, UserMinus, Hash } from 'lucide-react';
@@ -59,6 +59,38 @@ const PostCard = ({ post, onDelete, onUpdate, coords, showActions = false, route
     });
 
     const isOwner = currentUser && post.user?.email && currentUser.email === post.user.email;
+    const riderRequestStatus = !currentUser || isOwner || !isOffer
+        ? null
+        : listJoined
+            ? {
+                badgeClassName: 'bg-green-100 text-green-700',
+                title: 'Request accepted',
+                description: 'You are on the rider list for this trip.',
+            }
+            : listRequestSent
+                ? {
+                    badgeClassName: 'bg-amber-100 text-amber-700',
+                    title: 'Awaiting poster approval',
+                    description: 'Your join request has been sent and is waiting for the poster to respond.',
+                }
+                : null;
+
+    useEffect(() => {
+        setDriverList(post.drivers || []);
+        setListMembers(post.riderList || []);
+
+        if (!currentUser) {
+            setJoinRequested(false);
+            setListRequestSent(false);
+            return;
+        }
+
+        setJoinRequested(
+            (post.drivers || []).some(d => d.email === currentUser.email)
+            || (post.pendingDrivers || []).some(d => d.email === currentUser.email)
+        );
+        setListRequestSent((post.pendingJoins || []).includes(currentUser.email));
+    }, [post.drivers, post.pendingDrivers, post.pendingJoins, post.riderList, currentUser]);
 
     // Function to handle weather forecast dialog opening
     const openWeatherForecast = (location) => {
@@ -367,6 +399,18 @@ const PostCard = ({ post, onDelete, onUpdate, coords, showActions = false, route
                 </div>
             )}
 
+            {riderRequestStatus && (
+                <div className='mb-4 rounded-lg border border-gray-200 bg-slate-50 px-4 py-3'>
+                    <div className='flex items-center gap-2'>
+                        <span className={`text-xs font-medium px-2.5 py-0.5 rounded-full ${riderRequestStatus.badgeClassName}`}>
+                            Rider Request Status
+                        </span>
+                        <p className='text-sm font-medium text-gray-900'>{riderRequestStatus.title}</p>
+                    </div>
+                    <p className='mt-1 text-sm text-gray-600'>{riderRequestStatus.description}</p>
+                </div>
+            )}
+
             {/* Driver status */}
             {(() => {
                 const driver = driverList[0];
@@ -509,9 +553,9 @@ const PostCard = ({ post, onDelete, onUpdate, coords, showActions = false, route
                             {listJoinLoading ? (
                                 'Sending...'
                             ) : listJoined ? (
-                                <><CheckCircle className='w-4 h-4 mr-1' />On Rider List</>
+                                <><CheckCircle className='w-4 h-4 mr-1' />Request Accepted</>
                             ) : listRequestSent ? (
-                                <><CheckCircle className='w-4 h-4 mr-1' />Request Sent</>
+                                <><CheckCircle className='w-4 h-4 mr-1' />Awaiting Approval</>
                             ) : (
                                 <><Users className='w-4 h-4 mr-1' />Join the Rider List</>
                             )}
@@ -827,6 +871,18 @@ const PostCard = ({ post, onDelete, onUpdate, coords, showActions = false, route
                                     </div>
                                 )}
                             </div>
+
+                            {riderRequestStatus && (
+                                <div className='bg-gray-50 rounded-lg p-3 space-y-2'>
+                                    <p className='text-xs font-semibold uppercase tracking-wide text-gray-400'>Your Request Status</p>
+                                    <div className='flex items-center gap-2'>
+                                        <span className={`text-xs font-medium px-2.5 py-0.5 rounded-full ${riderRequestStatus.badgeClassName}`}>
+                                            {riderRequestStatus.title}
+                                        </span>
+                                    </div>
+                                    <p className='text-sm text-gray-600'>{riderRequestStatus.description}</p>
+                                </div>
+                            )}
 
                             {/* Trip details */}
                             {trip && (

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -74,12 +74,37 @@ function HomePage({ currentUser, onLogout }) {
   };
 
   const myPosts = useMemo(
-    () => visiblePosts.filter((p) => p.user?.email === currentUser?.email),
+    () =>
+      visiblePosts.filter((p) => {
+        const userEmail = currentUser?.email;
+        if (!userEmail) return false;
+
+        const isOwner = p.user?.email === userEmail;
+        const isAcceptedRider = Array.isArray(p.riderList)
+          && p.riderList.some((r) => r?.email === userEmail);
+        const isAcceptedDriver = Array.isArray(p.drivers)
+          && p.drivers.some((d) => d?.email === userEmail);
+
+        return isOwner || isAcceptedRider || isAcceptedDriver;
+      }),
     [visiblePosts, currentUser]
   );
 
   const availablePosts = useMemo(
-    () => visiblePosts.filter((p) => p.user?.email !== currentUser?.email),
+    () => {
+      const userEmail = currentUser?.email;
+      if (!userEmail) return visiblePosts;
+
+      return visiblePosts.filter((p) => {
+        const isOwner = p.user?.email === userEmail;
+        const isAcceptedRider = Array.isArray(p.riderList)
+          && p.riderList.some((r) => r?.email === userEmail);
+        const isAcceptedDriver = Array.isArray(p.drivers)
+          && p.drivers.some((d) => d?.email === userEmail);
+
+        return !isOwner && !isAcceptedRider && !isAcceptedDriver;
+      });
+    },
     [visiblePosts, currentUser]
   );
 


### PR DESCRIPTION
## Summary

Expands Issue #129 request-status UX in a focused way:
- keeps rider join request status visible
- adds rider-list leave/removal notifications to owner and remaining riders
- labels/stylizes leave events as Left List
- shows accepted rides in My Rides for accepted riders/drivers

Closes #129

## Changes

- PostCard
  - include actor metadata when leaving/removing from rider list
  - improve sharing count text when riders > 1
  - ensure API base defaults to /api
- posts/remove-member backend route
  - notify remaining riders + owner when someone leaves/is removed
  - include ride route/date/time in notification message
  - use left_list notification type
- NotificationMenu
  - add Left List badge and mild red styling
  - map legacy leave/removal message wording to Left List display type
  - ensure API base defaults to /api
- HomePage
  - include accepted rider/driver posts in My Rides
  - exclude those accepted posts from Available Rides

## How to Test

1. Sign in as post owner and at least one rider account.
2. Have rider join and get accepted.
3. Verify accepted rider sees the ride under My Rides.
4. Have rider leave (or owner remove rider).
5. Verify owner and remaining riders receive notification with type Left List (mild red) and ride info.

## Checklist

- [x] PR is under ~400 changed lines
- [ ] Branch follows naming convention: <author>/<type>/issue-<number>-<short-description>
- [ ] Commits reference the issue number (e.g., Add validation (#12))
- [ ] Tests pass
- [ ] At least one teammate has been requested for review
