### PR TITLE
Replace polling with WebSocket and Change Streams for real-time post u…

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -2,7 +2,7 @@ require('dotenv').config();
 
 const express = require('express');
 const cors = require('cors');
-const { connectDB } = require('./db');
+const { connectDB, getDB } = require('./db');
 const { Server }  = require('socket.io');
 const http = require('http');
 const postsRoutes = require('./routes/posts');
@@ -53,7 +53,70 @@ const io = new Server(server, {
 
 app.set('io', io);
 
+// Change Stream for realtime posts
+function setupPostsChangeStream() {
+  const db = getDB();
+  const postsCollection = db.collection('posts');
+
+  const changeStream = postsCollection.watch([], {
+    fullDocument: 'updateLookup'
+  });
+
+  console.log('MongoDB Change Stream setup for posts collection');
+
+  changeStream.on('change', async (change) => {
+    console.log('Posts change detected:', change.operationType);
+
+    try {
+      let post = change.fullDocument;
+
+      // Enrich with googleId if needed (referring to enrichPostsWithGoogleIds func in routes/posts.js)
+      if (post && post.user?.email && !post.user?.googleId) {
+        const user = await db.collection('users').findOne(
+          { email: post.user.email },
+          { projection: { googleId: 1 } }
+        );
+        if (user?.googleId) {
+          post.user.googleId = user.googleId;
+        }
+      }
+
+      switch (change.operationType) {
+        case 'insert':
+          io.emit('post:created', { post });
+          console.log('Broadcasted new post:', post._id);
+          break;
+
+        case 'update':
+        case 'replace':
+          if (post) {
+            io.emit('post:updated', { post });
+            console.log('Broadcasted updated post:', post._id);
+          }
+          break;
+
+        case 'delete':
+          const postId = change.documentKey._id.toString();
+          io.emit('post:deleted', { postId });
+          console.log('Broadcasted deleted post:', postId);
+          break;
+
+        default:
+          io.emit('posts:refresh');
+      }
+    } catch (err) {
+      console.error('Error processing change stream event:', err);
+    }
+  });
+
+  changeStream.on('error', (error) => {
+    console.error('Change stream error:', error);
+  });
+}
+
 connectDB().then(() => {
+  setupPostsChangeStream();
+  
   server.listen(PORT, () => {
     console.log(`Server listening on port ${PORT}`);
   });

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -6,3 +6,6 @@ VITE_API_BASE_URL=/api
 
 # Chat local url (change to deploy)
 CHAT_URL = http://localhost:3000
+
+# WebSocket URL for real-time updates. Pointing to local backend
+VITE_SOCKET_URL=http://localhost:3000

--- a/frontend/src/hooks/usePosts.js
+++ b/frontend/src/hooks/usePosts.js
@@ -1,10 +1,12 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useRef } from 'react';
+import { io } from 'socket.io-client';
 
 const API_ROOT = (import.meta.env.VITE_API_BASE_URL || '/api').replace(
     /\/$/,
     ''
 );
 const POSTS_ENDPOINT = `${API_ROOT}/posts`;
+const SOCKET_URL = import.meta.env.VITE_SOCKET_URL || window.location.origin;
 
 function toShortPlaceName(value) {
     const raw = typeof value === 'string' ? value.trim() : '';
@@ -17,9 +19,8 @@ function createPostPayload(formData) {
     const endShort = toShortPlaceName(formData.endTitle);
 
     return {
-        title: `${startShort || formData.startTitle} → ${
-            endShort || formData.endTitle
-        }`,
+        title: `${startShort || formData.startTitle} → ${endShort || formData.endTitle
+            }`,
         description: formData.description,
         type: formData.type,
         suggestedPrice: formData.type === 'offer' && formData.suggestedPrice ? Number(formData.suggestedPrice) : null,
@@ -75,6 +76,7 @@ export const usePosts = () => {
     const [isRefreshing, setIsRefreshing] = useState(false);
     const [error, setError] = useState('');
     const [lastUpdatedAt, setLastUpdatedAt] = useState(null);
+    const socketRef = useRef(null);
 
     const fetchPosts = useCallback(async () => {
         const response = await fetch(POSTS_ENDPOINT);
@@ -116,33 +118,89 @@ export const usePosts = () => {
         [fetchPosts]
     );
 
+    // WebSocket connection for real-time updates
     useEffect(() => {
-        refreshPosts().catch(() => {});
+        refreshPosts().catch(() => { });
 
-        const intervalId = window.setInterval(() => {
-            refreshPosts({ silent: true }).catch(() => {});
-        }, 30000);
+        const socket = io(SOCKET_URL, {
+            transports: ['websocket', 'polling'],
+        });
+        socketRef.current = socket;
 
-        const handleWindowFocus = () => {
-            refreshPosts({ silent: true }).catch(() => {});
-        };
+        socket.on('connect', () => {
+            console.log('Connected to posts socket:', socket.id);
+        });
 
-        const handleVisibilityChange = () => {
-            if (!document.hidden) {
-                refreshPosts({ silent: true }).catch(() => {});
+        socket.on('post:created', ({ post }) => {
+            console.log('Received new post:', post._id);
+            if (!post.archived) {
+                setPosts((prev) => {
+                    if (prev.some((p) => String(p._id) === String(post._id))) {
+                        return prev;
+                    }
+                    return [post, ...prev];
+                });
+                setLastUpdatedAt(new Date().toISOString());
             }
-        };
+        });
 
-        window.addEventListener('focus', handleWindowFocus);
-        document.addEventListener('visibilitychange', handleVisibilityChange);
+        socket.on('post:updated', ({ post }) => {
+            console.log('Received updated post:', post._id);
+            setPosts((prev) =>
+                prev
+                    .map((p) => (String(p._id) === String(post._id) ? post : p))
+                    .filter((p) => !p.archived)
+            );
+            setLastUpdatedAt(new Date().toISOString());
+        });
+
+        socket.on('post:deleted', ({ postId }) => {
+            console.log('Received deleted post:', postId);
+            setPosts((prev) => prev.filter((p) => String(p._id) !== String(postId)));
+            setLastUpdatedAt(new Date().toISOString());
+        });
+
+        socket.on('posts:refresh', () => {
+            console.log('Received refresh signal');
+            refreshPosts({ silent: true }).catch(() => { });
+        });
+
+        socket.on('disconnect', () => {
+            console.log('Disconnected from posts socket');
+        });
+
+        socket.on('connect_error', (err) => {
+            console.error('Socket connection error:', err.message);
+        });
 
         return () => {
-            window.clearInterval(intervalId);
-            window.removeEventListener('focus', handleWindowFocus);
-            document.removeEventListener('visibilitychange', handleVisibilityChange);
+            socket.disconnect();
+            socketRef.current = null;
         };
     }, [refreshPosts]);
 
+    // Fallback refresh on focus (only if socket disconnected)
+    useEffect(() => {
+        const handleFocus = () => {
+            if (!socketRef.current?.connected) {
+                refreshPosts({ silent: true }).catch(() => { });
+            }
+        };
+
+        const handleVisibility = () => {
+            if (!document.hidden && !socketRef.current?.connected) {
+                refreshPosts({ silent: true }).catch(() => { });
+            }
+        };
+
+        window.addEventListener('focus', handleFocus);
+        document.addEventListener('visibilitychange', handleVisibility);
+
+        return () => {
+            window.removeEventListener('focus', handleFocus);
+            document.removeEventListener('visibilitychange', handleVisibility);
+        };
+    }, [refreshPosts]);
 
     const addPost = useCallback(async (formData) => {
         const postPayload = createPostPayload(formData);
@@ -158,22 +216,14 @@ export const usePosts = () => {
             throw new Error(await readErrorMessage(response));
         }
 
-        const createdResult = await response.json();
-        const createdPost = {
+        const result = await response.json();
+        // Change Stream will broadcast to all clients. No local state update needed
+        return {
             ...postPayload,
-            _id: normalizeId(
-                createdResult.postId || createdResult.insertedId,
-                Date.now().toString()
-            ),
-            tripId: createdResult.tripId
-                ? normalizeId(createdResult.tripId, null)
-                : null,
+            _id: normalizeId(result.postId || result.insertedId, Date.now().toString()),
+            tripId: result.tripId ? normalizeId(result.tripId, null) : null,
+            confirmationCode: result.confirmationCode,
         };
-
-        setPosts((prevPosts) => [createdPost, ...prevPosts]);
-        setError('');
-        setLastUpdatedAt(new Date().toISOString());
-        return createdPost;
     }, []);
 
     const removePost = useCallback(async (postId) => {
@@ -184,11 +234,7 @@ export const usePosts = () => {
         if (!response.ok) {
             throw new Error(await readErrorMessage(response));
         }
-
-        setPosts((prevPosts) =>
-            prevPosts.filter((post) => String(post._id) !== String(postId))
-        );
-        setLastUpdatedAt(new Date().toISOString());
+        // Change Stream will broadcast to all clients
     }, []);
 
     const updatePost = useCallback(async (postId, formData) => {
@@ -204,16 +250,7 @@ export const usePosts = () => {
         if (!response.ok) {
             throw new Error(await readErrorMessage(response));
         }
-
-        // Update local state with the new data
-        setPosts((prevPosts) =>
-            prevPosts.map((post) =>
-                String(post._id) === String(postId)
-                    ? { ...post, ...postPayload }
-                    : post
-            )
-        );
-        setLastUpdatedAt(new Date().toISOString());
+        // Change Stream will broadcast to all clients
     }, []);
 
     return {


### PR DESCRIPTION
## Summary
Replace polling with real-time updates using MongoDB Change Streams and Socket.io

## Changes
- Add MongoDB Change Stream to detect post changes
- Broadcast changes via Socket.io to all clients
- Remove 30s polling interval
- Add VITE_SOCKET_URL env variable

## Files changed
- `backend/server.js` - Added Change Stream setup
- `frontend/src/hooks/usePosts.js` - Listen to WebSocket events
- `frontend/.env.example` - Added VITE_SOCKET_URL