### PR TITLE
Issue #158/#182: notify removed riders and restrict chat after leaving

### DIFF
--- a/backend/routes/chat.js
+++ b/backend/routes/chat.js
@@ -31,6 +31,10 @@ function validateEmail(email) {
   return email.trim().toLowerCase();
 }
 
+function normalizeEmail(email) {
+  return typeof email === 'string' ? email.trim().toLowerCase() : '';
+}
+
 function isActiveRideParticipant(post, email) {
   if (!post || !email) return false;
 
@@ -53,6 +57,24 @@ function isActiveRideParticipant(post, email) {
     : [];
 
   return driverEmails.includes(normalized);
+}
+
+function hasChatHistory(chat, email) {
+  if (!chat || !Array.isArray(chat.messages) || !email) return false;
+  const normalized = normalizeEmail(email);
+  return chat.messages.some((message) => normalizeEmail(message?.sender) === normalized);
+}
+
+function hasReadOnlyAccess(chat, email) {
+  if (!chat || !email) return false;
+  const normalized = normalizeEmail(email);
+  if (!normalized) return false;
+
+  const allowedReaders = Array.isArray(chat.allowedReaders)
+    ? chat.allowedReaders.map((item) => normalizeEmail(item)).filter(Boolean)
+    : [];
+
+  return allowedReaders.includes(normalized);
 }
 
 // Get or create chat for a post
@@ -83,24 +105,45 @@ router.get('/:postId', async (req, res) => {
       return res.status(400).json({ error: validationError.message });
     }
 
-    if (!isActiveRideParticipant(post, viewer)) {
+    let chat = await db.collection('chats').findOne({ _id: chatId });
+
+    const isActiveParticipant = isActiveRideParticipant(post, viewer);
+    const canReadHistory = hasChatHistory(chat, viewer) || hasReadOnlyAccess(chat, viewer);
+
+    // Read-only access policy:
+    // - active participants can read/create chat
+    // - former participants can read existing chat history if they have participated before
+    if (!isActiveParticipant && !canReadHistory) {
       return res.status(403).json({ error: 'You are not authorized to view this chat' });
     }
 
-    // Check if chat exists for this post
-    let chat = await db.collection('chats').findOne({ _id: chatId });
-
     if (!chat) {
+      if (!isActiveParticipant) {
+        return res.status(403).json({ error: 'You are not authorized to view this chat' });
+      }
+
       // Create new chat
       const newChat = {
         _id: chatId,
         postId,
         messages: [],
+        allowedReaders: [viewer],
         createdAt: new Date(),
         updatedAt: new Date()
       };
       await db.collection('chats').insertOne(newChat);
       chat = newChat;
+    } else if (isActiveParticipant) {
+      await db.collection('chats').updateOne(
+        { _id: chatId },
+        { $addToSet: { allowedReaders: viewer } }
+      );
+
+      if (!Array.isArray(chat.allowedReaders)) {
+        chat.allowedReaders = [viewer];
+      } else if (!chat.allowedReaders.includes(viewer)) {
+        chat.allowedReaders.push(viewer);
+      }
     }
 
     res.json(chat);
@@ -163,6 +206,7 @@ router.post('/:chatId/messages', async (req, res) => {
       { _id: chatObjectId },
       {
         $push: { messages: newMessage },
+        $addToSet: { allowedReaders: sender },
         $set: { updatedAt: new Date() }
       }
     );

--- a/backend/routes/chat.js
+++ b/backend/routes/chat.js
@@ -31,6 +31,30 @@ function validateEmail(email) {
   return email.trim().toLowerCase();
 }
 
+function isActiveRideParticipant(post, email) {
+  if (!post || !email) return false;
+
+  const normalized = validateEmail(email);
+  const ownerEmail = typeof post.user?.email === 'string' ? post.user.email.trim().toLowerCase() : '';
+  if (ownerEmail && ownerEmail === normalized) return true;
+
+  const riderEmails = Array.isArray(post.riderList)
+    ? post.riderList
+        .map((member) => (typeof member.email === 'string' ? member.email.trim().toLowerCase() : ''))
+        .filter(Boolean)
+    : [];
+
+  if (riderEmails.includes(normalized)) return true;
+
+  const driverEmails = Array.isArray(post.drivers)
+    ? post.drivers
+        .map((member) => (typeof member.email === 'string' ? member.email.trim().toLowerCase() : ''))
+        .filter(Boolean)
+    : [];
+
+  return driverEmails.includes(normalized);
+}
+
 // Get or create chat for a post
 router.get('/:postId', async (req, res) => {
   try {
@@ -96,6 +120,15 @@ router.post('/:chatId/messages', async (req, res) => {
     const chatObjectId = toObjectId(chatId);
     if (!chatObjectId) {
       return res.status(400).json({ error: 'Invalid chat ID' });
+    }
+
+    const post = await db.collection('posts').findOne({ _id: chatObjectId });
+    if (!post) {
+      return res.status(404).json({ error: 'Ride post not found' });
+    }
+
+    if (!isActiveRideParticipant(post, sender)) {
+      return res.status(403).json({ error: 'You are no longer part of this ride and cannot send new messages' });
     }
 
     const newMessage = {

--- a/backend/routes/chat.js
+++ b/backend/routes/chat.js
@@ -59,11 +59,32 @@ function isActiveRideParticipant(post, email) {
 router.get('/:postId', async (req, res) => {
   try {
     const { postId } = req.params;
+    const { viewerEmail } = req.query;
     const db = getDB();
 
     const chatId = toObjectId(postId);
     if (!chatId) {
       return res.status(400).json({ error: 'Invalid post ID' });
+    }
+
+    const post = await db.collection('posts').findOne({ _id: chatId });
+    if (!post) {
+      return res.status(404).json({ error: 'Ride post not found' });
+    }
+
+    if (!viewerEmail) {
+      return res.status(400).json({ error: 'viewerEmail is required' });
+    }
+
+    let viewer;
+    try {
+      viewer = validateEmail(viewerEmail);
+    } catch (validationError) {
+      return res.status(400).json({ error: validationError.message });
+    }
+
+    if (!isActiveRideParticipant(post, viewer)) {
+      return res.status(403).json({ error: 'You are not authorized to view this chat' });
     }
 
     // Check if chat exists for this post
@@ -164,7 +185,7 @@ router.post('/:chatId/messages', async (req, res) => {
 // GET all chats for a user
 router.get('/user/:email', async (req, res) => {
   try {
-    const { email } = req.params;
+    const email = validateEmail(req.params.email);
     const db = getDB();
 
     // Find all posts where the user is the owner, a rider, or a driver

--- a/backend/routes/notifications.js
+++ b/backend/routes/notifications.js
@@ -124,7 +124,10 @@ router.patch('/:id/respond', async (req, res) => {
           await db.collection('posts').updateOne(
             { _id: notif.postId },
             {
-              $pull: { pendingJoins: senderEmail },
+              $pull: {
+                pendingJoins: senderEmail,
+                riderList: { email: senderEmail },
+              },
               $push: { riderList: {
                 name: senderUser.name || senderUser.displayName || notif.senderName || '',
                 email: senderEmail,
@@ -152,7 +155,10 @@ router.patch('/:id/respond', async (req, res) => {
           await db.collection('posts').updateOne(
             { _id: notif.postId },
             {
-              $pull: { pendingDrivers: { email: senderUser.email } },
+              $pull: {
+                pendingDrivers: { email: senderUser.email },
+                drivers: { email: senderUser.email },
+              },
               $push: { drivers: {
                 name: senderUser.name || notif.senderName || '',
                 email: senderUser.email,

--- a/backend/routes/posts.js
+++ b/backend/routes/posts.js
@@ -694,20 +694,28 @@ router.post('/:id/remove-member', async (req, res) => {
     const post = await db.collection('posts').findOne({ _id: postId });
     if (!post) return res.status(404).json({ error: 'Post not found' });
 
-    // AUTHORIZATION CHECK: only post owner can remove members
+    // AUTHORIZATION CHECK:
+    // - post owner can remove any rider
+    // - a rider can remove themself (leave the ride)
     if (!actorEmail || !post.user?.email) {
-      return res.status(403).json({ error: 'Unauthorized: cannot verify ownership' });
+      return res.status(403).json({ error: 'Unauthorized: cannot verify actor' });
     }
-    
+
+    let actorNorm;
+    let ownerNorm;
     try {
-      const actorNorm = validateEmail(actorEmail);
-      const ownerNorm = validateEmail(post.user.email);
-      
-      if (actorNorm !== ownerNorm) {
-        return res.status(403).json({ error: 'Unauthorized: only post owner can remove members' });
-      }
+      actorNorm = validateEmail(actorEmail);
+      ownerNorm = validateEmail(post.user.email);
     } catch (err) {
       return res.status(400).json({ error: err.message });
+    }
+
+    const targetNorm = email || '';
+    const isOwnerAction = actorNorm === ownerNorm;
+    const isSelfLeave = Boolean(targetNorm) && actorNorm === targetNorm;
+
+    if (!isOwnerAction && !isSelfLeave) {
+      return res.status(403).json({ error: 'Unauthorized: only the post owner can remove riders' });
     }
 
     const riderListBefore = post.riderList || [];
@@ -732,26 +740,27 @@ router.post('/:id/remove-member', async (req, res) => {
     let notifiedCount = 0;
 
     const removedDisplayName = removedMember?.name || name || email;
-    const actorDisplayName = actorName || removedDisplayName;
-    const removedOwnself = actorEmail && actorEmail === email;
+    const actorDisplayName = actorName || post.user?.name || 'The poster';
+    const removedOwnself = isSelfLeave;
     const routeSummary = `${post.trip?.startLocation?.title || 'start'} to ${post.trip?.endLocation?.title || 'destination'}`;
     const dateSummary = post.trip?.date ? ` on ${post.trip.date}` : '';
     const timeSummary = post.trip?.time ? ` at ${post.trip.time}` : '';
     const rideSummary = `${routeSummary}${dateSummary}${timeSummary}`;
     const notificationMessage = removedOwnself
       ? `${removedDisplayName} left your riding list for ${rideSummary}.`
-      : `${removedDisplayName} was removed from your riding list for ${rideSummary} by ${actorDisplayName}.`;
+      : `You were removed from the riding list for ${rideSummary} by ${actorDisplayName}.`;
 
-    const recipientEmailSet = new Set(
-      remainingRiders
-        .map((member) => (typeof member.email === 'string' ? member.email.trim() : ''))
-        .filter(Boolean)
-    );
-    if (typeof post.user?.email === 'string' && post.user.email.trim()) {
-      recipientEmailSet.add(post.user.email.trim());
-    }
-    if (typeof email === 'string' && email.trim()) {
-      recipientEmailSet.delete(email.trim());
+    const recipientEmailSet = new Set();
+    if (removedOwnself) {
+      // Self-leave: notify post owner.
+      if (typeof post.user?.email === 'string' && post.user.email.trim()) {
+        recipientEmailSet.add(post.user.email.trim());
+      }
+    } else {
+      // Owner removal: notify the removed rider.
+      if (typeof email === 'string' && email.trim()) {
+        recipientEmailSet.add(email.trim());
+      }
     }
 
     const recipientEmails = Array.from(recipientEmailSet);

--- a/backend/routes/posts.js
+++ b/backend/routes/posts.js
@@ -550,10 +550,9 @@ router.post('/:id/join', async (req, res) => {
     }
 
     const riderList = post.riderList || [];
-    const pendingJoins = post.pendingJoins || [];
 
-    // Check if already joined or pending
-    if (riderList.some(u => u.email === email) || pendingJoins.includes(email)) {
+    // Check if already joined
+    if (riderList.some(u => u.email === email)) {
       return res.json({ success: true, alreadyJoined: true });
     }
 
@@ -561,10 +560,15 @@ router.post('/:id/join', async (req, res) => {
       return res.status(400).json({ error: 'This ride is full.' });
     }
 
-    await db.collection('posts').updateOne(
+    const joinResult = await db.collection('posts').updateOne(
       { _id: postId },
-      { $push: { pendingJoins: email } }
+      { $addToSet: { pendingJoins: email } }
     );
+
+    // No-op if request is already pending.
+    if (joinResult.modifiedCount === 0) {
+      return res.json({ success: true, alreadyJoined: true });
+    }
 
     // Notify the post owner
     const ownerEmail = post.user?.email;

--- a/backend/routes/posts.js
+++ b/backend/routes/posts.js
@@ -719,13 +719,23 @@ router.post('/:id/remove-member', async (req, res) => {
     }
 
     const riderListBefore = post.riderList || [];
-    const removedMember = riderListBefore.find((member) => member.email === email)
-      || riderListBefore.find((member) => name && member.name === name)
-      || null;
+    const removedMember = riderListBefore.find((member) => {
+      const memberEmail = typeof member.email === 'string' ? member.email.trim().toLowerCase() : '';
+      if (targetNorm && memberEmail === targetNorm) return true;
+      return !targetNorm && name && member.name === name;
+    }) || null;
+
+    if (!removedMember) {
+      return res.status(404).json({ error: 'Rider not found in this ride' });
+    }
+
+    if (isSelfLeave && !targetNorm) {
+      return res.status(400).json({ error: 'Self-leave requires a valid email' });
+    }
 
     await db.collection('posts').updateOne(
       { _id: postId },
-      { $pull: { riderList: { email: email || null } } }
+      { $pull: { riderList: { email: removedMember.email || null } } }
     );
     // Also remove any entry that matched on name if email was blank
     if (!email && name) {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -31,6 +31,10 @@ function AppRoutes({ currentUser, authApi }) {
     <>
       <Routes>
         <Route
+          path='/'
+          element={<Navigate to={currentUser ? '/home' : '/landing'} replace />}
+        />
+        <Route
           path='/landing'
           element={currentUser ? <Navigate to='/home' replace /> : <LandingPage onLogin={authApi.login} />}
         />

--- a/frontend/src/components/PostCard.jsx
+++ b/frontend/src/components/PostCard.jsx
@@ -747,22 +747,13 @@ const PostCard = ({ post, onDelete, onUpdate, coords, showActions = false, route
                                     const res = await fetch(`${API_ROOT}/posts/${post._id}/join`, {
                                         method: 'POST',
                                         headers: { 'Content-Type': 'application/json' },
-                                        body: JSON.stringify({ email: currentUser.email }),
+                                        body: JSON.stringify({
+                                            email: currentUser.email,
+                                            senderName: currentUser.name,
+                                            senderId: currentUser._id,
+                                        }),
                                     });
                                     if (res.ok) {
-                                        const msg = `${currentUser.name} wants to join your rider list for the ride from ${post.trip?.startLocation?.title || 'start'} to ${post.trip?.endLocation?.title || 'destination'}.`;
-                                        await fetch(NOTIFICATIONS_ENDPOINT, {
-                                            method: 'POST',
-                                            headers: { 'Content-Type': 'application/json' },
-                                            body: JSON.stringify({
-                                                recipientEmail: post.user.email,
-                                                senderName: currentUser.name,
-                                                senderId: currentUser._id,
-                                                message: msg,
-                                                postId: post._id,
-                                                type: 'join_list',
-                                            }),
-                                        });
                                         setListRequestSent(true);
                                     } else {
                                         const data = await res.json().catch(() => ({}));

--- a/frontend/src/components/PostCard.jsx
+++ b/frontend/src/components/PostCard.jsx
@@ -131,7 +131,8 @@ const PostCard = ({ post, onDelete, onUpdate, coords, showActions = false, route
     // Function to handle chatting
     const handleChatClick = async () => {
         try {
-            const response = await fetch(`${API_ROOT}/chat/${_id}`);
+            const viewerEmail = encodeURIComponent(currentUser?.email || '');
+            const response = await fetch(`${API_ROOT}/chat/${_id}?viewerEmail=${viewerEmail}`);
             if (!response.ok) {
                 throw new Error('Failed to get/create chat');
             }

--- a/frontend/src/components/RidesMapView.jsx
+++ b/frontend/src/components/RidesMapView.jsx
@@ -152,7 +152,7 @@ function AutoFitAfterSearch({ routeSearch, rides }) {
 
 
 
-function RidesMapView({ posts, currentUser, coords, routeSearch, onDeletePost, onUpdatePost }) {
+function RidesMapView({ posts, isLoading = false, currentUser, coords, routeSearch, onDeletePost, onUpdatePost }) {
   const [fromDate, setFromDate] = useState('');
   const [toDate, setToDate] = useState('');
   const [fromOpen, setFromOpen] = useState(false);
@@ -273,7 +273,12 @@ function RidesMapView({ posts, currentUser, coords, routeSearch, onDeletePost, o
         </div>
       </div>
 
-      {rides.length === 0 ? (
+      {isLoading ? (
+        <div className='rounded-xl border border-gray-200 shadow-sm h-[520px] flex flex-col items-center justify-center gap-4'>
+          <div className='w-10 h-10 rounded-full border-4 border-gray-200 border-t-gray-800 animate-spin' />
+          <p className='text-sm text-gray-400 animate-pulse'>Loading map rides...</p>
+        </div>
+      ) : rides.length === 0 ? (
         <div className='text-center py-12'>
           <p className='text-gray-500 text-lg'>No rides with location data to display.</p>
         </div>

--- a/frontend/src/hooks/useFriends.js
+++ b/frontend/src/hooks/useFriends.js
@@ -30,11 +30,27 @@ export function useFriends(userId) {
       }
       if (incomingRes.ok) {
         const data = await incomingRes.json();
-        setIncomingRequests(data.requests || []);
+        const uniqueIncoming = [];
+        const seenSenderIds = new Set();
+        for (const req of data.requests || []) {
+          const senderId = String(req?.sender?._id || '');
+          if (!senderId || seenSenderIds.has(senderId)) continue;
+          seenSenderIds.add(senderId);
+          uniqueIncoming.push(req);
+        }
+        setIncomingRequests(uniqueIncoming);
       }
       if (sentRes.ok) {
         const data = await sentRes.json();
-        setSentRequests(data.requests || []);
+        const uniqueSent = [];
+        const seenReceivers = new Set();
+        for (const req of data.requests || []) {
+          const receiverId = String(req?.receiverId || '');
+          if (!receiverId || seenReceivers.has(receiverId)) continue;
+          seenReceivers.add(receiverId);
+          uniqueSent.push(req);
+        }
+        setSentRequests(uniqueSent);
       }
       setError('');
     } catch (err) {
@@ -63,7 +79,12 @@ export function useFriends(userId) {
       throw new Error(data.error || 'Failed to send friend request');
     }
 
-    setSentRequests(prev => [...prev, { senderId: userId, receiverId: friendId }]);
+    setSentRequests((prev) => {
+      if (prev.some((r) => String(r.receiverId) === String(friendId))) {
+        return prev;
+      }
+      return [...prev, { senderId: userId, receiverId: friendId }];
+    });
   }, [userId]);
 
   // Keep addFriend as an alias for sendFriendRequest for backwards compat
@@ -83,10 +104,16 @@ export function useFriends(userId) {
 
     const data = await response.json();
     if (data.friend) {
-      setFriends(prev => [...prev, data.friend]);
+      setFriends((prev) => {
+        if (prev.some((f) => String(f._id) === String(data.friend._id))) {
+          return prev;
+        }
+        return [...prev, data.friend];
+      });
     }
-    setIncomingRequests(prev => prev.filter(r => r._id !== requestId));
-  }, [userId]);
+    setIncomingRequests((prev) => prev.filter((r) => String(r._id) !== String(requestId)));
+    await fetchFriends();
+  }, [userId, fetchFriends]);
 
   const rejectRequest = useCallback(async (requestId) => {
     if (!userId) return;
@@ -100,8 +127,9 @@ export function useFriends(userId) {
       throw new Error(data.error || 'Failed to reject request');
     }
 
-    setIncomingRequests(prev => prev.filter(r => r._id !== requestId));
-  }, [userId]);
+    setIncomingRequests((prev) => prev.filter((r) => String(r._id) !== String(requestId)));
+    await fetchFriends();
+  }, [userId, fetchFriends]);
 
   const cancelRequest = useCallback(async (requestId) => {
     if (!userId) return;
@@ -115,8 +143,9 @@ export function useFriends(userId) {
       throw new Error(data.error || 'Failed to cancel request');
     }
 
-    setSentRequests(prev => prev.filter(r => r._id !== requestId));
-  }, [userId]);
+    setSentRequests((prev) => prev.filter((r) => String(r._id) !== String(requestId)));
+    await fetchFriends();
+  }, [userId, fetchFriends]);
 
   const removeFriend = useCallback(async (friendId) => {
     if (!userId) return;

--- a/frontend/src/hooks/useNotifications.js
+++ b/frontend/src/hooks/useNotifications.js
@@ -2,7 +2,20 @@ import { useCallback, useEffect, useMemo, useState, useRef } from 'react';
 import { io } from 'socket.io-client';
 
 const API_ROOT = (import.meta.env.VITE_API_BASE_URL || '').replace(/\/$/, '');
-const SOCKET_URL = import.meta.env.VITE_SOCKET_URL || window.location.origin;
+const SOCKET_URL = (() => {
+    if (import.meta.env.VITE_SOCKET_URL) return import.meta.env.VITE_SOCKET_URL;
+    if (/^https?:\/\//i.test(API_ROOT)) {
+        try {
+            return new URL(API_ROOT, window.location.origin).origin;
+        } catch {
+            // Fall through to frontend origin.
+        }
+    }
+    if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
+        return `${window.location.protocol}//${window.location.hostname}:3000`;
+    }
+    return window.location.origin;
+})();
 
 async function parseNotificationResponse(response) {
     if (!response.ok) {

--- a/frontend/src/hooks/usePosts.js
+++ b/frontend/src/hooks/usePosts.js
@@ -6,7 +6,20 @@ const API_ROOT = (import.meta.env.VITE_API_BASE_URL || '/api').replace(
     ''
 );
 const POSTS_ENDPOINT = `${API_ROOT}/posts`;
-const SOCKET_URL = import.meta.env.VITE_SOCKET_URL || window.location.origin;
+const SOCKET_URL = (() => {
+    if (import.meta.env.VITE_SOCKET_URL) return import.meta.env.VITE_SOCKET_URL;
+    if (/^https?:\/\//i.test(API_ROOT)) {
+        try {
+            return new URL(API_ROOT, window.location.origin).origin;
+        } catch {
+            // Fall through to frontend origin.
+        }
+    }
+    if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
+        return `${window.location.protocol}//${window.location.hostname}:3000`;
+    }
+    return window.location.origin;
+})();
 
 function toShortPlaceName(value) {
     const raw = typeof value === 'string' ? value.trim() : '';

--- a/frontend/src/pages/ChatPage.jsx
+++ b/frontend/src/pages/ChatPage.jsx
@@ -421,6 +421,8 @@ const ChatPage = ({ currentUser }) => {
           value={message}
           onChange={(e) => setMessage(e.target.value)}
           onSubmit={() => handleSendMessage()}
+          placeholder={!canSendMessages ? 'cannot sent message in quitted group chat' : 'Type your message...'}
+          className={!canSendMessages ? 'text-center placeholder:text-center' : ''}
           disabled={!canSendMessages}
         />
         <ChatToolbarAddon align="inline-end">

--- a/frontend/src/pages/ChatPage.jsx
+++ b/frontend/src/pages/ChatPage.jsx
@@ -121,7 +121,12 @@ const ChatPage = ({ currentUser }) => {
 
     const fetchChat = async () => {
       try {
-        const response = await fetch(`${API_ROOT}/chat/${chatId}`);
+        const viewerEmail = encodeURIComponent(currentUser?.email || '');
+        const response = await fetch(`${API_ROOT}/chat/${chatId}?viewerEmail=${viewerEmail}`);
+        if (!response.ok) {
+          const payload = await response.json().catch(() => ({}));
+          throw new Error(payload.error || 'Failed to load chat');
+        }
         const chat = await response.json();
         setMessages(chat.messages || []);
       } catch (err) {
@@ -133,7 +138,7 @@ const ChatPage = ({ currentUser }) => {
     };
 
     fetchChat();
-  }, [chatId]);
+  }, [chatId, currentUser?.email]);
 
   useEffect(() => {
     if (messages.length === 0) return;
@@ -255,9 +260,21 @@ const ChatPage = ({ currentUser }) => {
   }, [messages, usersMap]);
 
   const participantCount = 1 + (post?.riderList?.length || 0) + (post?.drivers?.length || 0);
+  const currentEmail = (currentUser?.email || '').trim().toLowerCase();
+  const isOwner = currentEmail && (post?.user?.email || '').trim().toLowerCase() === currentEmail;
+  const isRider = Array.isArray(post?.riderList)
+    && post.riderList.some((rider) => (rider?.email || '').trim().toLowerCase() === currentEmail);
+  const isDriver = Array.isArray(post?.drivers)
+    && post.drivers.some((driver) => (driver?.email || '').trim().toLowerCase() === currentEmail);
+  const canSendMessages = Boolean(currentEmail && (isOwner || isRider || isDriver));
   
   const handleSendMessage = async () => {
     if (!message.trim() || !chatId) return;
+
+    if (!canSendMessages) {
+      setError('You can view this chat history, but you are no longer allowed to send messages for this ride.');
+      return;
+    }
 
     // FRONTEND VALIDATION: Prevent sending empty messages
     const trimmedMessage = message.trim();
@@ -404,13 +421,19 @@ const ChatPage = ({ currentUser }) => {
           value={message}
           onChange={(e) => setMessage(e.target.value)}
           onSubmit={() => handleSendMessage()}
+          disabled={!canSendMessages}
         />
         <ChatToolbarAddon align="inline-end">
-          <ChatToolbarButton onClick={handleSendMessage}>
+          <ChatToolbarButton onClick={handleSendMessage} disabled={!canSendMessages}>
             <SquareChevronRightIcon />
           </ChatToolbarButton>
         </ChatToolbarAddon>
       </ChatToolbar>
+      {!canSendMessages && (
+        <div className="px-4 pb-2 text-xs text-amber-700">
+          You were removed from this ride. Chat history remains visible, but sending new messages is disabled.
+        </div>
+      )}
 
       <Dialog open={detailsOpen} onOpenChange={setDetailsOpen}>
         <DialogContent className='sm:max-w-2xl max-h-[85vh] overflow-y-auto'>

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -292,6 +292,7 @@ function HomePage({ currentUser, onLogout }) {
       {activeView === 'map' && (
         <RidesMapView
           posts={visiblePosts}
+          isLoading={isLoading}
           currentUser={currentUser}
           coords={coords}
           routeSearch={routeSearch}


### PR DESCRIPTION
## Summary

Implements Issue #158 and Issue #182 by tightening rider-removal behavior, notification delivery, and chat authorization after ride membership changes.

Closes #158
Closes #182

## Changes

- allow rider self-leave while preserving owner-only removal of other riders
- return clear errors when the target rider is not found in the ride list
- notify removed rider when owner removes them from a ride
- notify post owner when a rider leaves voluntarily
- enforce chat access for active ride participants only
- require `viewerEmail` when opening a chat and validate membership before returning chat content
- block sending new messages after removal while preserving chat history visibility
- disable chat send controls in UI for users no longer in the ride
- add root route redirect so `/` no longer falls through to 404 (`/home` when logged in, `/landing` when logged out)

## How to Test

1. Start backend and frontend.
2. As owner, create a ride and accept a rider.
3. Remove that rider as owner; verify the removed rider receives notification.
4. Re-add rider, then have rider leave; verify owner receives notification.
5. After rider removal, open chat as removed rider; verify history is visible.
6. Try sending message as removed rider; verify send is blocked with clear message.
7. Open chat as owner/current participant; verify sending still works.
8. Open `http://localhost:5173`; verify it redirects to `/landing` (or `/home` if already logged in), not 404.

## Checklist

- [ ] PR is under ~400 changed lines
- [ ] Branch follows naming convention: `<author>/<type>/issue-<number>-<short-description>`
- [x] Commits reference issue numbers
- [ ] Tests pass
- [ ] At least one teammate has been requested for review
