### PR TITLE
Issue #281: Add price estimation link to posts

### DIFF
--- a/frontend/src/components/PostCard.jsx
+++ b/frontend/src/components/PostCard.jsx
@@ -508,6 +508,18 @@ const PostCard = ({ post, onDelete, onUpdate, coords, showActions = false, route
                 </div>
             )}
 
+            <div className='flex items-center gap-2 mb-4 text-sm'>
+                <ExternalLink className='w-4 h-4 text-gray-400 shrink-0' />
+                <a
+                    href='https://www.uber.com/global/en/price-estimate/'
+                    target='_blank'
+                    rel='noreferrer'
+                    className='font-medium text-blue-600 hover:text-blue-800 hover:underline'
+                >
+                    See price estimation here
+                </a>
+            </div>
+
             {/* Driver status */}
             {(() => {
                 const driver = driverList[0];


### PR DESCRIPTION
## Summary

Adds an Uber price estimate link to every post card so users can quickly compare ride pricing while reviewing posts.

Closes #281

## Changes

- add a visible "See price estimation here" link to each post card
- open the Uber price estimator in a new tab
- keep the submit form unchanged so the estimate link only appears on posts
- sync the branch with latest `develop`

## How to Test

1. Open Home and view the ride posts list.
2. Confirm every post card shows "See price estimation here".
3. Click the link and verify it opens `https://www.uber.com/global/en/price-estimate/` in a new tab.
4. Confirm the submit form does not show the price estimation link.

## Checklist

- [ ] PR is under ~400 changed lines
- [ ] Branch follows naming convention: `<author>/<type>/issue-<number>-<short-description>`
- [x] Commits reference issue numbers
- [x] Tests pass
- [ ] At least one teammate has been requested for review
