### PR TITLE
Fix deployed weather component

### DIFF
--- a/frontend/src/components/PostCard.jsx
+++ b/frontend/src/components/PostCard.jsx
@@ -7,6 +7,7 @@ import { useNavigate } from 'react-router-dom';
 import { formatTime, formatDate } from '@/lib/utils';
 import { MapPin, Calendar, Clock, MessageCircle, Pencil, Trash2, Info, User, Mail, Phone, Navigation, ExternalLink, UserPlus, Users, UserMinus, CheckCircle, Star } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { getCalendarDayDiff } from '@/lib/dateUtils';
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { HoverCard, HoverCardTrigger, HoverCardContent } from '@/components/ui/hover-card';
 import {
@@ -225,15 +226,7 @@ const PostCard = ({ post, onDelete, onUpdate, coords, showActions = false, route
     // Check if weather should be displayed (within 14 days and not in the past)
     const shouldShowWeather = () => {
         if (!trip?.date) return false;
-        
-        const targetDate = new Date(trip.date);
-        const today = new Date();
-        
-        // Reset time to start of day for accurate day comparison
-        today.setHours(0, 0, 0, 0);
-        targetDate.setHours(0, 0, 0, 0);
-        
-        const diffDays = Math.ceil((targetDate - today) / (1000 * 60 * 60 * 24));
+        const diffDays = getCalendarDayDiff(trip.date);
         
         // Only show weather for dates that are today or in the future, and within 14 days
         return diffDays >= 0 && diffDays <= 14;

--- a/frontend/src/components/WeatherDisplay.jsx
+++ b/frontend/src/components/WeatherDisplay.jsx
@@ -1,27 +1,28 @@
 import React, { useState, useEffect } from 'react';
-import { Cloud, Sun, CloudRain, CloudSnow, Wind, Droplets, Thermometer } from 'lucide-react';
+import { Cloud, CloudSun, Sun, CloudRain, CloudSnow, Wind, Droplets, Thermometer } from 'lucide-react';
 import { useWeather } from '../hooks/useWeather';
 import { getWeatherIconUrl } from '../services/weatherService';
 
 const WeatherIcon = ({ condition, iconCode }) => {
   // Fallback icons if API icon fails
-  const iconMap = {
-    Clear: Sun,
-    Clouds: Cloud,
-    Rain: CloudRain,
-    Snow: CloudSnow,
-    Drizzle: CloudRain,
-  };
-  
-  const FallbackIcon = iconMap[condition] || Cloud;
+  const normalizedCondition = condition?.toLowerCase() || '';
+  const FallbackIcon = normalizedCondition.includes('partly cloudy')
+    ? CloudSun
+    : normalizedCondition.includes('clear') || normalizedCondition.includes('sunny')
+      ? Sun
+      : normalizedCondition.includes('rain') || normalizedCondition.includes('drizzle')
+        ? CloudRain
+        : normalizedCondition.includes('snow')
+          ? CloudSnow
+          : Cloud;
   
   return (
-    <div className="flex items-center justify-center w-8 h-8">
+    <div className="flex items-center justify-center w-8 h-8 shrink-0">
       {iconCode ? (
         <img 
           src={getWeatherIconUrl(iconCode)}
           alt={condition}
-          className="w-8 h-8"
+          className="max-w-8 max-h-8 object-contain"
           onError={(e) => {
             e.target.style.display = 'none';
             e.target.nextSibling.style.display = 'block';

--- a/frontend/src/components/WeatherDisplay.jsx
+++ b/frontend/src/components/WeatherDisplay.jsx
@@ -22,7 +22,7 @@ const WeatherIcon = ({ condition, iconCode }) => {
         <img 
           src={getWeatherIconUrl(iconCode)}
           alt={condition}
-          className="max-w-8 max-h-8 object-contain"
+          className="w-8 h-8 min-w-8 object-contain"
           onError={(e) => {
             e.target.style.display = 'none';
             e.target.nextSibling.style.display = 'block';

--- a/frontend/src/components/WeatherForecastDialog.jsx
+++ b/frontend/src/components/WeatherForecastDialog.jsx
@@ -1,9 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from './ui/dialog';
 import { Cloud, Sun, CloudRain, CloudSnow, Wind, Droplets, Thermometer } from 'lucide-react';
-import { getWeatherIconUrl } from '../services/weatherService';
-
-const API_ROOT = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000').replace(/\/$/, '');
+import { API_ROOT, getWeatherIconUrl } from '../services/weatherService';
+import { formatDateOnly } from '../lib/dateUtils';
 
 export const WeatherForecastDialog = ({ open, onOpenChange, latitude, longitude, location, currentDate }) => {
   const [forecast, setForecast] = useState([]);
@@ -43,7 +42,7 @@ export const WeatherForecastDialog = ({ open, onOpenChange, latitude, longitude,
   };
 
   useEffect(() => {
-    if (!open || !latitude || !longitude) {
+    if (!open || latitude == null || longitude == null) {
       setForecast([]);
       setError(null);
       return;
@@ -63,11 +62,16 @@ export const WeatherForecastDialog = ({ open, onOpenChange, latitude, longitude,
           targetDate.setDate(targetDate.getDate() + i);
           
           // Format date as YYYY-MM-DD
-          const dateStr = targetDate.toISOString().split('T')[0];
+          const dateStr = formatDateOnly(targetDate);
           
           try {
+            const params = new URLSearchParams({
+              lat: String(latitude),
+              lon: String(longitude),
+              date: dateStr,
+            });
             const response = await fetch(
-              `${API_ROOT}/weather/forecast?lat=${latitude}&lon=${longitude}&date=${dateStr}`,
+              `${API_ROOT}/weather/forecast?${params}`,
               {
                 headers: {
                   'Content-Type': 'application/json',

--- a/frontend/src/components/WeatherForecastDialog.jsx
+++ b/frontend/src/components/WeatherForecastDialog.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from './ui/dialog';
-import { Cloud, Sun, CloudRain, CloudSnow, Wind, Droplets, Thermometer } from 'lucide-react';
+import { Cloud, CloudSun, Sun, CloudRain, CloudSnow, Wind, Droplets, Thermometer } from 'lucide-react';
 import { API_ROOT, getWeatherIconUrl } from '../services/weatherService';
 import { formatDateOnly } from '../lib/dateUtils';
 
@@ -10,23 +10,24 @@ export const WeatherForecastDialog = ({ open, onOpenChange, latitude, longitude,
   const [error, setError] = useState(null);
 
   const WeatherIcon = ({ condition, iconCode, size = 'w-8 h-8' }) => {
-    const iconMap = {
-      Clear: Sun,
-      Clouds: Cloud,
-      Rain: CloudRain,
-      Snow: CloudSnow,
-      Drizzle: CloudRain,
-    };
-    
-    const FallbackIcon = iconMap[condition] || Cloud;
+    const normalizedCondition = condition?.toLowerCase() || '';
+    const FallbackIcon = normalizedCondition.includes('partly cloudy')
+      ? CloudSun
+      : normalizedCondition.includes('clear') || normalizedCondition.includes('sunny')
+        ? Sun
+        : normalizedCondition.includes('rain') || normalizedCondition.includes('drizzle')
+          ? CloudRain
+          : normalizedCondition.includes('snow')
+            ? CloudSnow
+            : Cloud;
     
     return (
-      <div className={`flex items-center justify-center ${size}`}>
+      <div className={`flex items-center justify-center shrink-0 ${size}`}>
         {iconCode ? (
           <img 
             src={getWeatherIconUrl(iconCode)}
             alt={condition}
-            className={size}
+            className={`${size} object-contain`}
             onError={(e) => {
               e.target.style.display = 'none';
               e.target.nextSibling.style.display = 'block';

--- a/frontend/src/hooks/useWeather.js
+++ b/frontend/src/hooks/useWeather.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { getWeatherForecast } from '../services/weatherService';
+import { getCalendarDayDiff } from '../lib/dateUtils';
 
 export function useWeather(latitude, longitude, date, time) {
   const [weather, setWeather] = useState(null);
@@ -8,20 +9,12 @@ export function useWeather(latitude, longitude, date, time) {
   const timeoutRef = useRef(null);
 
   useEffect(() => {
-    if (!latitude || !longitude || !date) {
+    if (latitude == null || longitude == null || !date) {
       setWeather(null);
       return;
     }
 
-    // Check if date is within 14 days from today (same logic as weatherService)
-    const targetDate = new Date(date);
-    const today = new Date();
-    
-    // Reset time to start of day for accurate day comparison
-    today.setHours(0, 0, 0, 0);
-    targetDate.setHours(0, 0, 0, 0);
-    
-    const diffDays = Math.ceil((targetDate - today) / (1000 * 60 * 60 * 24));
+    const diffDays = getCalendarDayDiff(date);
 
     // Don't even start loading for dates beyond 14 days
     if (diffDays > 14) {

--- a/frontend/src/lib/dateUtils.js
+++ b/frontend/src/lib/dateUtils.js
@@ -1,0 +1,31 @@
+export function parseDateOnly(date) {
+    if (date instanceof Date) {
+        return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+    }
+
+    if (typeof date === 'string') {
+        const match = date.match(/^(\d{4})-(\d{2})-(\d{2})/);
+        if (match) {
+            return new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
+        }
+    }
+
+    const parsed = new Date(date);
+    return new Date(parsed.getFullYear(), parsed.getMonth(), parsed.getDate());
+}
+
+export function getCalendarDayDiff(date, baseDate = new Date()) {
+    const targetDate = parseDateOnly(date);
+    const today = parseDateOnly(baseDate);
+
+    return Math.ceil((targetDate - today) / (1000 * 60 * 60 * 24));
+}
+
+export function formatDateOnly(date) {
+    const localDate = parseDateOnly(date);
+    const year = localDate.getFullYear();
+    const month = String(localDate.getMonth() + 1).padStart(2, '0');
+    const day = String(localDate.getDate()).padStart(2, '0');
+
+    return `${year}-${month}-${day}`;
+}

--- a/frontend/src/lib/dateUtils.test.js
+++ b/frontend/src/lib/dateUtils.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { formatDateOnly, getCalendarDayDiff, parseDateOnly } from './dateUtils';
+
+describe('parseDateOnly', () => {
+    it('parses YYYY-MM-DD strings as local calendar dates', () => {
+        const parsed = parseDateOnly('2026-05-01');
+
+        expect(parsed.getFullYear()).toBe(2026);
+        expect(parsed.getMonth()).toBe(4);
+        expect(parsed.getDate()).toBe(1);
+    });
+});
+
+describe('getCalendarDayDiff', () => {
+    it('treats the same YYYY-MM-DD calendar date as today', () => {
+        const diff = getCalendarDayDiff('2026-05-01', new Date(2026, 4, 1, 15));
+
+        expect(diff).toBe(0);
+    });
+});
+
+describe('formatDateOnly', () => {
+    it('formats dates without shifting through UTC', () => {
+        expect(formatDateOnly(new Date(2026, 4, 1, 23))).toBe('2026-05-01');
+    });
+});

--- a/frontend/src/services/weatherService.js
+++ b/frontend/src/services/weatherService.js
@@ -1,7 +1,8 @@
-// Weather service that calls our backend API
-// Backend handles weather API calls securely with server-side caching
+import { getCalendarDayDiff } from '../lib/dateUtils';
 
-const API_ROOT = (import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000').replace(/\/$/, '');
+// Weather service that calls our backend API.
+// Backend handles weather API calls securely with server-side caching.
+export const API_ROOT = (import.meta.env.VITE_API_BASE_URL || '/api').replace(/\/$/, '');
 
 // Simple cache to avoid redundant requests within the same session
 const cache = new Map();
@@ -18,19 +19,11 @@ setInterval(() => {
 }, 10 * 60 * 1000); // Clean every 10 minutes
 
 export async function getWeatherForecast(latitude, longitude, date, time = '12:00') {
-  if (!latitude || !longitude || !date) {
+  if (latitude == null || longitude == null || !date) {
     return null;
   }
 
-  // Check if date is within 14 days from today
-  const targetDate = new Date(date);
-  const today = new Date();
-  
-  // Reset time to start of day for accurate day comparison
-  today.setHours(0, 0, 0, 0);
-  targetDate.setHours(0, 0, 0, 0);
-  
-  const diffDays = Math.ceil((targetDate - today) / (1000 * 60 * 60 * 24));
+  const diffDays = getCalendarDayDiff(date);
 
   // Only provide weather forecast for dates within 14 days from today
   if (diffDays > 14) {
@@ -49,8 +42,8 @@ export async function getWeatherForecast(latitude, longitude, date, time = '12:0
   try {
     // Call our backend weather API
     const params = new URLSearchParams({
-      lat: latitude.toString(),
-      lon: longitude.toString(),
+      lat: String(latitude),
+      lon: String(longitude),
       date: date,
       time: time
     });

--- a/frontend/src/services/weatherService.test.js
+++ b/frontend/src/services/weatherService.test.js
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { API_ROOT, getWeatherForecast } from './weatherService';
+
+describe('weatherService', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(2026, 4, 1, 12));
+        global.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: vi.fn().mockResolvedValue({ temp: 22, condition: 'Sunny' }),
+        });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+        delete global.fetch;
+    });
+
+    it('defaults weather requests to the deployed app API path', async () => {
+        await getWeatherForecast(39.33, -76.62, '2026-05-01');
+
+        const requestUrl = global.fetch.mock.calls[0][0];
+        expect(API_ROOT).toBe('/api');
+        expect(requestUrl).toBe('/api/weather/forecast?lat=39.33&lon=-76.62&date=2026-05-01&time=12%3A00');
+    });
+
+    it('accepts zero coordinates as valid weather coordinates', async () => {
+        const result = await getWeatherForecast(0, 0, '2026-05-02');
+
+        expect(result).toEqual({ temp: 22, condition: 'Sunny' });
+        expect(global.fetch).toHaveBeenCalledWith(
+            '/api/weather/forecast?lat=0&lon=0&date=2026-05-02&time=12%3A00'
+        );
+    });
+
+    it('skips weather requests more than 14 calendar days away', async () => {
+        const result = await getWeatherForecast(39.33, -76.62, '2026-05-16');
+
+        expect(result).toBeNull();
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Description
Fixes the deployed weather component so it uses the deployed API path, handles date-only trip dates consistently, and keeps compact weather icons from stretching.

## Related Issue
Closes #191

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other

## Changes Made
- Updated weather API defaults from localhost to the deployed app API path.
- Added local calendar-date helpers to avoid timezone shifts for YYYY-MM-DD trip dates.
- Allowed zero-valued coordinates and safely encoded weather forecast query params.
- Fixed compact weather icon sizing for conditions like Partly cloudy.
- Added focused tests for weather request behavior and date utilities.

## Testing
- [x] npm test -- --run
- [x] npm run build

## Screenshots
Preview deployment is available from the Vercel check on this PR.